### PR TITLE
Patch DECLARE_TXN_V1 version

### DIFF
--- a/api/starknet_api_openrpc.json
+++ b/api/starknet_api_openrpc.json
@@ -1735,7 +1735,7 @@
                                 "description": "Version of the transaction scheme",
                                 "type": "string",
                                 "enum": [
-                                    "0x0",
+                                    "0x1",
                                     "0x100000000000000000000000000000001"
                                 ]
                             },


### PR DESCRIPTION
DECLARE_TXN_V1 should have version "0x1" as before.